### PR TITLE
Implement: CropWitherEvent & PotWitherEvent

### DIFF
--- a/api/src/main/java/net/momirealms/customcrops/api/event/CropWitherEvent.java
+++ b/api/src/main/java/net/momirealms/customcrops/api/event/CropWitherEvent.java
@@ -7,7 +7,13 @@ import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * This event is called, when
+ * This class represents an event triggered when a crop is about to wither,
+ * occurring prior to its actual withering process.
+ *
+ * <p>
+ * It provides functionality to handle the event related to a crop's withering,
+ * allowing actions to be taken preemptively before the crop actually withers.
+ * </p>
  *
  * @author GommeHD.net Development Team
  */

--- a/api/src/main/java/net/momirealms/customcrops/api/event/CropWitherEvent.java
+++ b/api/src/main/java/net/momirealms/customcrops/api/event/CropWitherEvent.java
@@ -1,0 +1,47 @@
+package net.momirealms.customcrops.api.event;
+
+import org.bukkit.Location;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This event is called, when
+ *
+ * @author GommeHD.net Development Team
+ */
+public class CropWitherEvent extends Event implements Cancellable {
+
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+
+    private final @NotNull Location location;
+    private boolean cancelled;
+
+    public CropWitherEvent(@NotNull Location location) {
+        this.location = location;
+    }
+
+    public @NotNull Location location() {
+        return this.location;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    public static @NotNull HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+}

--- a/api/src/main/java/net/momirealms/customcrops/api/event/PotWitherEvent.java
+++ b/api/src/main/java/net/momirealms/customcrops/api/event/PotWitherEvent.java
@@ -1,0 +1,53 @@
+package net.momirealms.customcrops.api.event;
+
+import org.bukkit.Location;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This class represents an event triggered when a pot is about to wither,
+ * occurring prior to its actual withering process.
+ *
+ * <p>
+ * It provides functionality to handle the event related to a pot's withering,
+ * allowing actions to be taken preemptively before the pot actually withers.
+ * </p>
+ *
+ * @author GommeHD.net Development Team
+ */
+public class PotWitherEvent extends Event implements Cancellable {
+
+    private static final HandlerList HANDLER_LIST = new HandlerList();
+
+    private final @NotNull Location location;
+    private boolean cancelled;
+
+    public PotWitherEvent(@NotNull Location location) {
+        this.location = location;
+    }
+
+    public @NotNull Location location() {
+        return this.location;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return HANDLER_LIST;
+    }
+
+    public static @NotNull HandlerList getHandlerList() {
+        return HANDLER_LIST;
+    }
+}

--- a/plugin/src/main/java/net/momirealms/customcrops/mechanic/world/block/MemoryCrop.java
+++ b/plugin/src/main/java/net/momirealms/customcrops/mechanic/world/block/MemoryCrop.java
@@ -21,6 +21,7 @@ import com.flowpowered.nbt.CompoundMap;
 import com.flowpowered.nbt.IntTag;
 import com.flowpowered.nbt.StringTag;
 import net.momirealms.customcrops.api.CustomCropsPlugin;
+import net.momirealms.customcrops.api.event.CropWitherEvent;
 import net.momirealms.customcrops.api.mechanic.action.ActionTrigger;
 import net.momirealms.customcrops.api.mechanic.condition.Condition;
 import net.momirealms.customcrops.api.mechanic.condition.DeathConditions;
@@ -126,6 +127,11 @@ public class MemoryCrop extends AbstractCustomCropsBlock implements WorldCrop {
             for (Condition condition : deathConditions.getConditions()) {
                 if (condition.isConditionMet(this)) {
                     CustomCropsPlugin.get().getScheduler().runTaskSyncLater(() -> {
+                        final CropWitherEvent event = new CropWitherEvent(location.getBukkitLocation());
+                        if (!event.callEvent()) {
+                            return;
+                        }
+
                         CustomCropsPlugin.get().getWorldManager().removeCropAt(location);
                         CustomCropsPlugin.get().getItemManager().removeAnythingAt(bukkitLocation);
                         if (deathConditions.getDeathItem() != null) {

--- a/plugin/src/main/java/net/momirealms/customcrops/mechanic/world/block/MemoryPot.java
+++ b/plugin/src/main/java/net/momirealms/customcrops/mechanic/world/block/MemoryPot.java
@@ -22,6 +22,7 @@ import com.flowpowered.nbt.IntTag;
 import com.flowpowered.nbt.StringTag;
 import com.flowpowered.nbt.Tag;
 import net.momirealms.customcrops.api.CustomCropsPlugin;
+import net.momirealms.customcrops.api.event.PotWitherEvent;
 import net.momirealms.customcrops.api.mechanic.item.Fertilizer;
 import net.momirealms.customcrops.api.mechanic.item.ItemType;
 import net.momirealms.customcrops.api.mechanic.item.Pot;
@@ -221,6 +222,13 @@ public class MemoryPot extends AbstractCustomCropsBlock implements WorldPot {
                 loseWater = true;
             }
             setWater(water);
+        }
+
+        if ((water - 1) <= 0) {
+            final PotWitherEvent event = new PotWitherEvent(Objects.requireNonNull(super.getLocation().getBukkitLocation()));
+            if (!event.callEvent()) {
+                return;
+            }
         }
 
         if (loseFertilizer || loseWater) {


### PR DESCRIPTION
This pull request introduces two new events, `CropWitherEvent` and `PotWitherEvent`, to the API. These events are pivotal for handling crop and pot withering processes.

**CropWitherEvent:**
This event is triggered when a crop is about to wither, signaling the need for preemptive actions to prevent or mitigate its withering process. It provides an opportunity for developers to implement custom logic.

**PotWitherEvent:**
Similarly, this event is fired when a pot is on the verge of withering, allowing developers to intervene before the pot deteriorates. It enables the implementation of specific actions.
